### PR TITLE
Fix how plugin_path is used.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
 }
 
 ext.kotlin_version = '1.3.61'
-ext.plugin_path = '' //Put your plugins folder directory here! If it is left as '', jars won't be copied
 
 group = 'com.derongan.minecraft'
 version = plugin_version + "-SNAPSHOT"
@@ -30,6 +29,15 @@ repositories {
     mavenLocal()
     jcenter()
     maven { url 'https://jitpack.io' } //JitPack
+
+    maven {
+        name = "MineInAbyss"
+        url = uri("https://maven.pkg.github.com/MineInAbyss/Idofront")
+        credentials {
+            username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
+            password = project.findProperty("gpr.key") ?: System.getenv("PASSWORD")
+        }
+    }
 }
 
 dependencies {
@@ -45,7 +53,7 @@ dependencies {
     else implementation 'com.github.mineinabyss:guiy:kotlin-dsl-SNAPSHOT'
 
     if (useLocalIdofront.toBoolean()) implementation project(':idofront')
-    else implementation 'com.github.mineinabyss:idofront:master-SNAPSHOT'
+    else implementation group: 'com.mineinabyss', name: 'idofront', version: '0.1.0-SNAPSHOT'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
@@ -71,18 +79,11 @@ compileKotlin { kotlinOptions { jvmTarget = "1.8" } }
 compileTestKotlin { kotlinOptions { jvmTarget = "1.8" } }
 
 //Move into plugins folder
-if (plugin_path != '') {
-    println("Copying to plugin directory")
+if (project.hasProperty("plugin_path") && plugin_path) {
+    println("Copying to plugin directory $plugin_path")
     task copyJar(type: Copy) {
         from shadowJar // here it automatically reads jar file produced from jar task
         into plugin_path
     }
     build.dependsOn copyJar
-} else if (parent != null && parent.hasProperty("plugin_path")) {
-    println("Copying to parent project's plugin directory")
-    task copyJar(type: Copy) {
-        from shadowJar
-        into parent.ext.plugin_path
-    }
-    build.dependsOn copyJar
-} else println("Skipped copyJar")
+}


### PR DESCRIPTION
Now source from project properties organically rather than using extended properties
Simplify using parents properties
Show directory being copied into