### PR TITLE
Disable curse scaling factor

### DIFF
--- a/src/main/java/com/derongan/minecraft/mineinabyss/ascension/AscensionListener.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/ascension/AscensionListener.kt
@@ -39,9 +39,9 @@ class AscensionListener : Listener {
         val from = moveEvent.from
         val to = moveEvent.to
 
-        for (passenger in moveEvent.vehicle.passengers)
-            if (passenger != null && passenger is Player)
-                handleCurse(passenger, to, from)
+        moveEvent.vehicle.passengers.filterIsInstance<Player>().forEach { passenger ->
+            handleCurse(passenger, to, from)
+        }
     }
 
     private fun handleCurse(player: Player, to: Location, from: Location) {

--- a/src/main/java/com/derongan/minecraft/mineinabyss/world/AbyssWorldManagerImpl.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/world/AbyssWorldManagerImpl.kt
@@ -35,8 +35,8 @@ class AbyssWorldManagerImpl(config: Configuration) : AbyssWorldManager {
         val subHeader = map[SUB_KEY] as String
 
         val layer = LayerImpl(layerName, subHeader, numLayers++, deathMessage = " ${map.getOrDefault(DEATH_MESSAGE_KEY, "in $layerName")}",
-                maxCurseMultiplier = map["maxCurseMultiplier"] as? Float ?: 2f,
-                minCurseMultiplier =  map["minCurseMultiplier"] as? Float ?: 0.5f,
+                maxCurseMultiplier = map["maxCurseMultiplier"] as? Float ?: 1f, //default to this effect being off
+                minCurseMultiplier = map["minCurseMultiplier"] as? Float ?: 1f,
                 maxCurseRadius = map["maxCurseRadius"] as? Float ?: 1000f,
                 minCurseRadius = map["minCurseRadius"] as? Float ?: 2000f,
                 curseOverrideRegions = emptyList(),

--- a/src/main/java/com/derongan/minecraft/mineinabyss/world/AbyssWorldManagerImpl.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/world/AbyssWorldManagerImpl.kt
@@ -35,7 +35,7 @@ class AbyssWorldManagerImpl(config: Configuration) : AbyssWorldManager {
         val subHeader = map[SUB_KEY] as String
 
         val layer = LayerImpl(layerName, subHeader, numLayers++, deathMessage = " ${map.getOrDefault(DEATH_MESSAGE_KEY, "in $layerName")}",
-                maxCurseMultiplier = map["maxCurseMultiplier"] as? Float ?: 1f, //default to this effect being off
+                maxCurseMultiplier = map["maxCurseMultiplier"] as? Float ?: 1f, //default to a constant curse strength multiplier of 1
                 minCurseMultiplier = map["minCurseMultiplier"] as? Float ?: 1f,
                 maxCurseRadius = map["maxCurseRadius"] as? Float ?: 1000f,
                 minCurseRadius = map["minCurseRadius"] as? Float ?: 2000f,

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,8 +3,8 @@ version: @plugin_version@
 author: Derongan
 main: com.derongan.minecraft.mineinabyss.MineInAbyss
 api-version: '1.15'
-softdepend: [Multiverse-Core]
-depend: [DeeperWorld, Vault, Geary]
+softdepend: [Multiverse-Core, Geary]
+depend: [DeeperWorld, Vault]
 
 prefix: MiB
 description: A mod that adds abyss effects


### PR DESCRIPTION
Default curse scaling factor to 1, so it always stays consistent with 10 blocks. The system should be reworked eventually, but this essentially puts it back to its original state now.

Additionally, change Geary to a softdepend as it is currently disabled on the survival server.