### PR TITLE
update Depth Meter for world height changes

### DIFF
--- a/src/main/java/com/derongan/minecraft/mineinabyss/ecs/AbyssLocationAction.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/ecs/AbyssLocationAction.kt
@@ -21,14 +21,16 @@ class AbyssLocationAction : GearyAction() {
 
     override fun GearyEntity.run(): Boolean {
         val player = parent?.get<Player>() ?: return false
-        val accuracy = depthMeter.accuracy
+        val sectionXOffset = depthMeter.sectionXOffset
+        val sectionYOffset = depthMeter.sectionYOffset
+        val abyssStartingHeightInOrth = depthMeter.abyssStartingHeightInOrth
         val section = player.location.section
         val layer: Layer? = section?.layer
 
         if (layer == null) {
             player.sendMessage("$ITALIC${DARK_AQUA}The compass wiggles slightly but does not otherwise respond.")
         } else {
-            val depth = accuracy * (getDepth(layer, section, player.location) / accuracy)
+            val depth = getDepth(sectionXOffset, sectionYOffset, abyssStartingHeightInOrth, player.location)
             player.sendMessage(
                 """
                 $DARK_AQUA${ITALIC}The needle spins.
@@ -39,31 +41,23 @@ class AbyssLocationAction : GearyAction() {
         return true
     }
 
-    // TODO memoize total depth of each layer
     // TODO move into an API elsewhere
-    private fun getDepth(layer: Layer, section: Section, location: Location): Int {
-        var totalDepth = 0
-        var currentSectionTop = 0
-        val numSections = layer.sections.size
-        layer.sections.forEachIndexed { index, s ->
-            run {
-                if (section == s) {
-                    currentSectionTop = totalDepth
-                }
-                totalDepth += if (index != numSections - 1) {
-                    s.referenceTop.y.toInt()
-                } else {
-                    // This isn't totally accurate since there is overlap with the next layer, but 256 is a good best guess.
-                    256
-                }
-            }
-        }
+    /**
+     * Calculates the depth of the player in the abyss, in minecraft blocks.
+     *
+     * @param sectionXOffset                how far apart sections actually are, horizontally
+     * @param sectionYOffset                how far apart sections are pretending to be, vertically
+     * @param abyssStartingHeightInOrth     at what y value (in Orth) the Depth Meter should say 0. 128 is the big golden bridge
+     * @param location                      Location object obtained from Player
+     *
+     * @return  depth of player in abyss, in minecraft blocks
+     */
 
-        val minecraftDepth = currentSectionTop + (256 - location.y)
-        val layerDepth = layer.endDepth - layer.startDepth
+    private fun getDepth(sectionXOffset: Int, sectionYOffset: Int, abyssStartingHeightInOrth: Int, location: Location): Int {
 
-        return (layer.startDepth + minecraftDepth / totalDepth * layerDepth).toInt()
-            .coerceIn(layer.startDepth, layer.endDepth)
+        val numSectionsDeep =  (location.x / sectionXOffset) as Int //number of sections under Orth. If in Orth, this should be 0
+
+        return (location.y - abyssStartingHeightInOrth - (numSectionsDeep * sectionYOffset)) as Int
     }
 
     private fun pluralizeMeters(count: Int): String {

--- a/src/main/java/com/derongan/minecraft/mineinabyss/ecs/DepthMeter.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/ecs/DepthMeter.kt
@@ -8,5 +8,7 @@ import kotlinx.serialization.Serializable
 @SerialName("mineinabyss:depthmeter")
 @AutoscanComponent
 data class DepthMeter(
-    val accuracy: Int = 1
+    val sectionXOffset: Int = 16384,
+    val sectionYOffset: Int = 480,
+    val abyssStartingHeightInOrth: Int = 128
 )


### PR DESCRIPTION
Depth Meter uses **player coords + configurable offsets** instead of layer + section data to calculate the virtual depth of the player in the Abyss. The Depth reading is given in minecraft blocks, not corresponding to canon depth.