### PR TITLE
Fix KeeepInv check for bottom of map

### DIFF
--- a/src/main/java/com/derongan/minecraft/mineinabyss/ascension/AscensionListener.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/ascension/AscensionListener.kt
@@ -29,16 +29,13 @@ object AscensionListener : Listener {
     private val recentlyMovedPlayers: MutableSet<UUID> = HashSet()
 
     @EventHandler(ignoreCancelled = true)
-    fun onPlayerMove(moveEvent: PlayerMoveEvent) {
-        val (player, from, to) = moveEvent
+    fun PlayerMoveEvent.onPlayerMove() {
         handleCurse(player, from, to)
     }
 
     @EventHandler(ignoreCancelled = true)
-    fun onMove(moveEvent: VehicleMoveEvent) {
-        val (_, from, to) = moveEvent
-
-        moveEvent.vehicle.passengers.filterIsInstance<Player>().forEach { passenger ->
+    fun VehicleMoveEvent.onMove() {
+        vehicle.passengers.filterIsInstance<Player>().forEach { passenger ->
             handleCurse(passenger, from, to)
         }
     }
@@ -54,8 +51,8 @@ object AscensionListener : Listener {
 
     @EventHandler(ignoreCancelled = true)
     fun PlayerTeleportEvent.onTeleport() {
-        val (player, from, to) = this
-        if (this.cause == PlayerTeleportEvent.TeleportCause.ENDER_PEARL || this.cause == PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT)
+        if (this.cause == PlayerTeleportEvent.TeleportCause.ENDER_PEARL ||
+            this.cause == PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT)
             handleCurse(player, from, to)
     }
 
@@ -121,10 +118,10 @@ object AscensionListener : Listener {
     private fun onPlayerDescend(e: PlayerDescendEvent) = onPlayerChangeSection(e)
 
     @EventHandler
-    fun onEnterVehicle(e: VehicleEnterEvent) {
-        val player = e.entered
+    fun VehicleEnterEvent.onEnterVehicle() {
+        val player = entered
         if (player is Player) {
-            handleCurse(player, from = player.location, to = e.vehicle.location)
+            handleCurse(player, from = player.location, to = vehicle.location)
         }
     }
 
@@ -146,11 +143,10 @@ object AscensionListener : Listener {
     }
 
     @EventHandler
-    fun onPlayerDeath(deathEvent: PlayerDeathEvent) {
-        val (player) = deathEvent
-        val section = player.location.section ?: return
+    fun PlayerDeathEvent.onPlayerDeath() {
+        val section = entity.location.section ?: return
         val layerOfDeath = section.layer ?: return
-        deathEvent.apply {
+        apply {
             deathMessage += " ${layerOfDeath.deathMessage}"
         }
     }

--- a/src/main/java/com/derongan/minecraft/mineinabyss/configuration/MIAConfig.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/configuration/MIAConfig.kt
@@ -26,11 +26,13 @@ internal object MIAConfig : IdofrontConfig<MIAConfig.Data>(
 
     /**
      * @param layers A list of all the layers and sections composing them to be registered.
+     * @param keepInvInVoid Specifies if keepinventory should be enabled if player dies in void.
      * @property hubSection The hub section of the abyss, a safe place for living and trading.
      */
     @Serializable
     class Data(
         val storage: Storage,
+        val keepInvInVoid: Boolean,
         val layers: List<LayerImpl>, //TODO way of changing the serializer from service
         private val hubSectionName: String = "orth",
     ) {

--- a/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerListener.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerListener.kt
@@ -66,8 +66,9 @@ object PlayerListener : Listener {
         val playerData = getPlayerData(entity)
         val cause = entity.lastDamageCause?.cause
 
-        //TODO maybe limit this to only the survival server with a config option
-        if (cause == EntityDamageEvent.DamageCause.VOID) keepInventory = true
+        if ((cause == EntityDamageEvent.DamageCause.VOID || cause == EntityDamageEvent.DamageCause.CUSTOM) &&
+            entity.location.block.type == Material.VOID_AIR &&
+            MIAConfig.data.keepInvInVoid) keepInventory = true
         if (!playerData.isIngame) return
         playerData.isIngame = false
         entity.sendMessage(

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,7 @@ x-particles-vomit: &vomit
 # effect names are each effect class' @SerialName
 storage:
   relicpath: "relics/"
+keepInvInVoid: true
 layers:
   - name: Orth
     sub: City of the Great Pit


### PR DESCRIPTION
Due to the air damage being a custom event, it would often fail to enable keepinv for players in void.
Also made it configurable