### PR TITLE
Option to toggle Keep Inventory

### DIFF
--- a/src/main/java/com/derongan/minecraft/mineinabyss/commands/AscensionCommandExecutor.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/commands/AscensionCommandExecutor.kt
@@ -5,6 +5,7 @@ import com.derongan.minecraft.mineinabyss.playerData
 import com.mineinabyss.idofront.commands.execution.ExperimentalCommandDSL
 import com.mineinabyss.idofront.commands.execution.IdofrontCommandExecutor
 import com.mineinabyss.idofront.commands.extensions.actions.playerAction
+import com.mineinabyss.idofront.messaging.error
 import com.mineinabyss.idofront.messaging.success
 
 @ExperimentalCommandDSL
@@ -24,7 +25,19 @@ object AscensionCommandExecutor : IdofrontCommandExecutor() {
         "curseoff" {
             playerAction {
                 player.playerData.isAffectedByCurse = false
-                sender.success("Curse disabled for ${player.name}")
+                sender.error("Curse disabled for ${player.name}")
+            }
+        }
+        "keepinvon" {
+            playerAction {
+                player.playerData.keepInvStatus = true
+                sender.success("Keep Inventory enabled for ${player.name}")
+            }
+        }
+        "keepinvoff" {
+            playerAction {
+                player.playerData.keepInvStatus = false
+                sender.error("Keep Inventory disabled for ${player.name}")
             }
         }
     }

--- a/src/main/java/com/derongan/minecraft/mineinabyss/commands/CommandLabels.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/commands/CommandLabels.kt
@@ -4,6 +4,8 @@ package com.derongan.minecraft.mineinabyss.commands
 object CommandLabels {
     const val CURSEON = "curseon"
     const val CURSEOFF = "curseoff"
+    const val KEEPINVON = "keepinvon"
+    const val KEEPINVOFF = "keepinvoff"
     const val STATS = "stats"
     const val START = "start"
     const val STOP_DESCENT = "stopdescent"

--- a/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerData.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerData.kt
@@ -11,6 +11,7 @@ import java.util.*
  *
  * Change with caution. You are responsible for moving the player so data is not out of sync.
  * @property isAffectedByCurse Whether the player is affected by the curse of ascending in the abyss.
+ * @property keepInvStatus Whether the player keeps their inventory upon death.
  * @property ascensionEffects The mutable list of current effects on this player.
  * @property curseAccrued The distance the player has ascended since last being affected by the curse.
  *
@@ -26,6 +27,7 @@ interface PlayerData {
     val player: Player
     var currentLayer: Layer?
     var isAffectedByCurse: Boolean
+    var keepInvStatus: Boolean
     val ascensionEffects: List<AscensionEffect>
     var curseAccrued: Double
     val level: Int

--- a/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerDataImpl.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerDataImpl.kt
@@ -30,6 +30,7 @@ class PlayerDataImpl(
     override var expOnDescent: Double = 0.0,
     @Serializable(with = DateAsLongSerializer::class)
     override var descentDate: Date? = null,
+    override var keepInvStatus: Boolean = true,
 ) : PlayerData {
     @Transient
     override var currentLayer: Layer? = null

--- a/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerListener.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerListener.kt
@@ -66,11 +66,8 @@ object PlayerListener : Listener {
         val playerData = getPlayerData(player)
 
         if (!playerData.keepInvStatus) {
-            for (itemStack in entity.inventory) {
-                if (itemStack == null) return
-                player.world.dropItemNaturally(player.location, itemStack)
-                player.inventory.removeItem(itemStack)
-            }
+            entity.inventory.contents.filterNotNull().forEach { player.world.dropItemNaturally(player.location, it) }
+            player.inventory.clear()
         }
 
         //TODO maybe limit this to only the survival server with a config option

--- a/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerListener.kt
+++ b/src/main/java/com/derongan/minecraft/mineinabyss/player/PlayerListener.kt
@@ -13,13 +13,13 @@ import com.mineinabyss.idofront.messaging.color
 import com.mineinabyss.idofront.messaging.error
 import com.mineinabyss.idofront.messaging.logWarn
 import org.bukkit.ChatColor
+import org.bukkit.Sound
+import org.bukkit.SoundCategory
 import org.bukkit.attribute.Attribute
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
-import org.bukkit.Sound
-import org.bukkit.SoundCategory
 import org.bukkit.event.block.Action
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.EntityDamageEvent
@@ -61,12 +61,20 @@ object PlayerListener : Listener {
     }
 
     @EventHandler
-    fun onPlayerDeath(pde: PlayerDeathEvent) {
-        val player = pde.entity
+    fun PlayerDeathEvent.onPlayerDeath() {
+        val player = entity
         val playerData = getPlayerData(player)
 
+        if (!playerData.keepInvStatus) {
+            for (itemStack in entity.inventory) {
+                if (itemStack == null) return
+                player.world.dropItemNaturally(player.location, itemStack)
+                player.inventory.removeItem(itemStack)
+            }
+        }
+
         //TODO maybe limit this to only the survival server with a config option
-        if (player.lastDamageCause?.cause == EntityDamageEvent.DamageCause.VOID) pde.keepInventory = true
+        if (player.lastDamageCause?.cause == EntityDamageEvent.DamageCause.VOID) keepInventory = true
         if (!playerData.isIngame) return
         playerData.isIngame = false
         player.sendMessage(

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,10 @@ commands:
     description: Turn on the curse of ascension
   curseoff:
     description: Turn off the curse of ascension
+  keepinvon:
+    description: Turn on Keep Inventory
+  keepinvoff:
+    description: Turn off Keep Inventory
   stats:
     description: Shows statistics about you!
   start:
@@ -32,6 +36,12 @@ permissions:
     description: Allows players to enable the curse of ascension on themselves
   mineinabyss.curse.off:
     description: Allows players to disable the curse of ascension on themselves
+  mineinabyss.keepinv.toggle:
+    description: Allows players to toggle Keep Inventory on themselves
+  mineinabyss.keepinv.on:
+    description: Allows players to enable Keep Inventory on others
+  mineinabyss.keepinv.off:
+    description: Allows players to disable Keep Inventory on others
   mineinabyss.stopdescent:
     description: Allows players to leave a run
   mineinabyss.start:


### PR DESCRIPTION
Solves #91 

Currently only drops hotbar slots for some reason.
![image](https://user-images.githubusercontent.com/62521371/135138331-b94d1c3b-c9a6-4e10-b9a8-c324f7707141.png)

Tried using additional checks ontop like `entity.inventory.storageContents` and `entity.inventory.extraContents`
Neither removed anything other than hotbar (not armor or extra inv space)
Also probably way better ways to drop the items, simply setting keepinv to false removed all items

Permissions are also abit weird, but cannot see why as it is identical to the curse check afaik
![image](https://user-images.githubusercontent.com/62521371/135138734-205a4003-64a9-40e7-9948-5c6c2d819128.png)