### PR TITLE
Star compass, depth meter fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.mineinabyss
 version=0.12
-idofrontVersion=0.21.5
+idofrontVersion=0.21.6

--- a/mineinabyss-components/src/main/kotlin/com/mineinabyss/components/PlayerData.kt
+++ b/mineinabyss-components/src/main/kotlin/com/mineinabyss/components/PlayerData.kt
@@ -24,7 +24,8 @@ class PlayerData(
     var showPlayerBalance: Boolean = true,
     var displayProfileArmor: Boolean = true,
     var defaultDisplayLockState: Boolean = false,
-    var recentInteractEntity: @Serializable(with = UUIDSerializer::class) UUID? = null
+    var recentInteractEntity: @Serializable(with = UUIDSerializer::class) UUID? = null,
+    var replant: Boolean = true,
 ) {
     val level: Int get() = exp.toInt() / 10 //TODO write a proper formula
 

--- a/mineinabyss-components/src/main/kotlin/com/mineinabyss/components/relics/ShowStarCompassHud.kt
+++ b/mineinabyss-components/src/main/kotlin/com/mineinabyss/components/relics/ShowStarCompassHud.kt
@@ -6,4 +6,4 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @SerialName("mineinabyss:show_starcompass_hud")
-class ShowStarCompassHud(val lastSection: Section? = null)
+class ShowStarCompassHud()

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/misc/MiscFeature.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/misc/MiscFeature.kt
@@ -1,7 +1,12 @@
 package com.mineinabyss.features.misc
 
+import com.mineinabyss.components.playerData
+import com.mineinabyss.idofront.commands.extensions.actions.playerAction
 import com.mineinabyss.idofront.features.Feature
 import com.mineinabyss.idofront.features.FeatureDSL
+import com.mineinabyss.idofront.messaging.error
+import com.mineinabyss.idofront.messaging.info
+import com.mineinabyss.idofront.messaging.success
 import com.mineinabyss.idofront.plugin.listeners
 
 class MiscFeature : Feature() {

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/misc/MiscListener.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/misc/MiscListener.kt
@@ -7,7 +7,6 @@ import com.mineinabyss.idofront.entities.rightClicked
 import nl.rutgerkok.blocklocker.BlockLockerAPIv2
 import org.bukkit.GameMode
 import org.bukkit.Material
-import org.bukkit.Tag
 import org.bukkit.block.BlockFace
 import org.bukkit.block.Lectern
 import org.bukkit.block.data.Bisected

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/DoToggleStarCompassHud.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/DoToggleStarCompassHud.kt
@@ -6,16 +6,12 @@ import com.mineinabyss.deeperworld.world.section.section
 import com.mineinabyss.geary.annotations.optin.UnsafeAccessors
 import com.mineinabyss.geary.datatypes.family.family
 import com.mineinabyss.geary.helpers.parent
-import com.mineinabyss.geary.papermc.datastore.decodePrefabs
-import com.mineinabyss.geary.prefabs.PrefabKey
+import com.mineinabyss.geary.papermc.datastore.encodeComponentsTo
 import com.mineinabyss.geary.systems.GearyListener
 import com.mineinabyss.geary.systems.accessors.Pointers
 import com.mineinabyss.idofront.items.editItemMeta
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.Player
-import org.bukkit.event.EventHandler
-import org.bukkit.event.Listener
-import org.bukkit.event.inventory.PrepareGrindstoneEvent
 import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.CompassMeta
@@ -26,6 +22,7 @@ class DoToggleStarCompassHud : GearyListener() {
 
     @OptIn(UnsafeAccessors::class)
     override fun Pointers.handle() {
+        val item = item
         val player = target.entity.parent?.get<Player>() ?: return
         if (target.entity.has<ShowStarCompassHud>()) {
             item.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1)
@@ -44,15 +41,7 @@ class DoToggleStarCompassHud : GearyListener() {
                 isLodestoneTracked = false
             }
         }
+        target.entity.encodeComponentsTo(item)
     }
 }
 
-class StarCompassBukkitListener : Listener {
-    @EventHandler
-    fun PrepareGrindstoneEvent.onGrindStarCompass() {
-        if (this.result?.itemMeta?.persistentDataContainer?.decodePrefabs()
-                ?.contains(PrefabKey.of("mineinabyss:star_compass")) == true
-        )
-            result = null
-    }
-}

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/RelicsFeature.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/RelicsFeature.kt
@@ -8,8 +8,8 @@ import com.mineinabyss.idofront.plugin.listeners
 class RelicsFeature : Feature() {
     override fun FeatureDSL.enable() {
         geary.pipeline.addSystems(
-            ToggleStarCompassHudSystem(),
-            ToggleStarCompassHudRepeatingSystem(),
+            DoToggleStarCompassHud(),
+            TrackStarCompassHudOnPlayers(),
         )
         plugin.listeners(StarCompassBukkitListener())
     }

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/StarCompassBukkitListener.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/StarCompassBukkitListener.kt
@@ -1,0 +1,20 @@
+package com.mineinabyss.features.relics
+
+import com.mineinabyss.geary.papermc.datastore.decodePrefabs
+import com.mineinabyss.geary.prefabs.PrefabKey
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.PrepareGrindstoneEvent
+
+class StarCompassBukkitListener : Listener {
+    @EventHandler
+    fun PrepareGrindstoneEvent.onGrindStarCompass() {
+        if (result?.itemMeta
+                ?.persistentDataContainer
+                ?.decodePrefabs()
+                ?.contains(PrefabKey.of("mineinabyss:star_compass")) != true
+        ) return
+
+        result = null
+    }
+}

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/TrackStarCompassHudOnPlayers.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/TrackStarCompassHudOnPlayers.kt
@@ -1,0 +1,38 @@
+package com.mineinabyss.features.relics
+
+import com.mineinabyss.components.relics.ShowStarCompassHud
+import com.mineinabyss.components.relics.StarCompass
+import com.mineinabyss.geary.annotations.optin.UnsafeAccessors
+import com.mineinabyss.geary.datatypes.GearyEntity
+import com.mineinabyss.geary.helpers.parent
+import com.mineinabyss.geary.systems.RepeatingSystem
+import com.mineinabyss.geary.systems.accessors.Pointer
+import com.mineinabyss.geary.systems.query.GearyQuery
+import com.mineinabyss.idofront.time.ticks
+import org.bukkit.entity.Player
+
+class TrackStarCompassHudOnPlayers : RepeatingSystem(5.ticks) {
+    private val Pointer.compass by get<StarCompass>()
+    private val hudEnabledQuery = object: GearyQuery() {
+        val Pointer.player by get<Player>()
+        val Pointer.hudShown by get<ShowStarCompassHud>()
+    }
+
+    @OptIn(UnsafeAccessors::class)
+    override fun tickAll() {
+        val oldPlayersWithHud = hudEnabledQuery.matchedEntities.toSet()
+        val newPlayersWithHud = mutableSetOf<GearyEntity>()
+        forEach {
+            val player = it.entity.parent ?: return@forEach
+            newPlayersWithHud += player
+        }
+
+        // Update component on players that need an update
+        oldPlayersWithHud.minus(newPlayersWithHud).forEach {
+            it.remove<ShowStarCompassHud>()
+        }
+        newPlayersWithHud.minus(oldPlayersWithHud).forEach {
+            it.set(ShowStarCompassHud())
+        }
+    }
+}

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/TrackStarCompassHudOnPlayers.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/relics/TrackStarCompassHudOnPlayers.kt
@@ -12,7 +12,8 @@ import com.mineinabyss.idofront.time.ticks
 import org.bukkit.entity.Player
 
 class TrackStarCompassHudOnPlayers : RepeatingSystem(5.ticks) {
-    private val Pointer.compass by get<StarCompass>()
+    private val Pointer.hudShown by get<ShowStarCompassHud>()
+
     private val hudEnabledQuery = object: GearyQuery() {
         val Pointer.player by get<Player>()
         val Pointer.hudShown by get<ShowStarCompassHud>()

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/ToolsFeature.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/ToolsFeature.kt
@@ -1,5 +1,6 @@
 package com.mineinabyss.features.tools
 
+import com.mineinabyss.components.playerData
 import com.mineinabyss.features.tools.depthmeter.DepthHudSystem
 import com.mineinabyss.features.tools.depthmeter.DepthMeterBukkitListener
 import com.mineinabyss.features.tools.depthmeter.ShowDepthSystem
@@ -11,12 +12,30 @@ import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.idofront.commands.extensions.actions.playerAction
 import com.mineinabyss.idofront.features.Feature
 import com.mineinabyss.idofront.features.FeatureDSL
+import com.mineinabyss.idofront.messaging.error
+import com.mineinabyss.idofront.messaging.info
+import com.mineinabyss.idofront.messaging.success
 import com.mineinabyss.idofront.plugin.listeners
 
 class ToolsFeature : Feature() {
     override val dependsOn: Set<String> = setOf("DeeperWorld")
     override fun FeatureDSL.enable() {
         mainCommand {
+            "replant" {
+                playerAction {
+                    player.playerData.replant = !player.playerData.replant
+                    when {
+                        player.playerData.replant -> {
+                            player.success("Crops will now automatically be replanted!")
+                            if (sender != player) sender.info("Crops will now automatically be replanted for ${player.name}!")
+                        }
+                        else -> {
+                            player.error("Crops will not automatically be replanted!")
+                            if (sender != player) sender.info("Crops will not automatically be replanted for ${player.name}!")
+                        }
+                    }
+                }
+            }
             "depth" {
                 playerAction {
                     ShowDepthSystem().run {
@@ -24,6 +43,10 @@ class ToolsFeature : Feature() {
                     }
                 }
             }
+        }
+        tabCompletion {
+            if (args.size == 1) listOf("replant", "depth").filter { it.startsWith(args[0]) }
+            else emptyList()
         }
         geary.pipeline.addSystems(
             ShowDepthSystem(),

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/ToolsFeature.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/ToolsFeature.kt
@@ -3,7 +3,7 @@ package com.mineinabyss.features.tools
 import com.mineinabyss.features.tools.depthmeter.DepthHudSystem
 import com.mineinabyss.features.tools.depthmeter.DepthMeterBukkitListener
 import com.mineinabyss.features.tools.depthmeter.ShowDepthSystem
-import com.mineinabyss.features.tools.depthmeter.ToggleDepthHudSystem
+import com.mineinabyss.features.tools.depthmeter.DoToggleDepthHud
 import com.mineinabyss.features.tools.grapplinghook.GrapplingHookListener
 import com.mineinabyss.features.tools.sickle.HarvestListener
 import com.mineinabyss.features.tools.sickle.SickleListener
@@ -27,7 +27,7 @@ class ToolsFeature : Feature() {
         }
         geary.pipeline.addSystems(
             ShowDepthSystem(),
-            ToggleDepthHudSystem(),
+            DoToggleDepthHud(),
             DepthHudSystem(),
             HarvestListener(),
         )

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DepthHudSystem.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DepthHudSystem.kt
@@ -17,7 +17,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.inventory.PrepareGrindstoneEvent
 
 class DepthHudSystem : RepeatingSystem(5.ticks) {
-    private val Pointer.depthMeter by get<DepthMeter>()
+    private val Pointer.hudShown by get<ShowDepthMeterHud>()
 
     private val hudEnabledQuery = object : GearyQuery() {
         val Pointer.player by get<Player>()

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DepthHudSystem.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DepthHudSystem.kt
@@ -2,31 +2,44 @@ package com.mineinabyss.features.tools.depthmeter
 
 import com.mineinabyss.components.tools.DepthMeter
 import com.mineinabyss.components.tools.ShowDepthMeterHud
+import com.mineinabyss.geary.annotations.optin.UnsafeAccessors
+import com.mineinabyss.geary.datatypes.GearyEntity
+import com.mineinabyss.geary.helpers.parent
 import com.mineinabyss.geary.papermc.datastore.decodePrefabs
-import com.mineinabyss.geary.papermc.tracking.entities.toGeary
-import com.mineinabyss.geary.papermc.tracking.items.inventory.toGeary
 import com.mineinabyss.geary.prefabs.PrefabKey
 import com.mineinabyss.geary.systems.RepeatingSystem
 import com.mineinabyss.geary.systems.accessors.Pointer
+import com.mineinabyss.geary.systems.query.GearyQuery
 import com.mineinabyss.idofront.time.ticks
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.inventory.PrepareGrindstoneEvent
 
 class DepthHudSystem : RepeatingSystem(5.ticks) {
-    private val Pointer.player by get<Player>()
+    private val Pointer.depthMeter by get<DepthMeter>()
 
-    override fun Pointer.tick() {
-        if (!player.isConnected) return
-        val depthMeters = player.inventory.withIndex().filter { player.inventory.toGeary()?.get(it.index)?.has<DepthMeter>() == true }.mapNotNull { it.value }
-        when {
-            depthMeters.any { Enchantment.ARROW_INFINITE !in it.enchantments } ->
-                player.toGeary().add<ShowDepthMeterHud>()
-            else -> player.toGeary().remove<ShowDepthMeterHud>()
+    private val hudEnabledQuery = object : GearyQuery() {
+        val Pointer.player by get<Player>()
+        val Pointer.hudShown by get<ShowDepthMeterHud>()
+    }
+
+    // TODO refactor for code reuse
+    @OptIn(UnsafeAccessors::class)
+    override fun tickAll() {
+        val oldPlayersWithHud = hudEnabledQuery.matchedEntities.toSet()
+        val newPlayersWithHud = mutableSetOf<GearyEntity>()
+        forEach {
+            val player = it.entity.parent ?: return@forEach
+            newPlayersWithHud += player
+        }
+
+        // Update component on players that need an update
+        oldPlayersWithHud.minus(newPlayersWithHud).forEach {
+            it.remove<ShowDepthMeterHud>()
+        }
+        newPlayersWithHud.minus(oldPlayersWithHud).forEach {
+            it.set(ShowDepthMeterHud())
         }
     }
 }
@@ -34,7 +47,9 @@ class DepthHudSystem : RepeatingSystem(5.ticks) {
 class DepthMeterBukkitListener : Listener {
     @EventHandler
     fun PrepareGrindstoneEvent.onGrindDepthMeter() {
-        if (this.result?.itemMeta?.persistentDataContainer?.decodePrefabs()?.contains(PrefabKey.of("mineinabyss:depth_meter")) == true)
+        if (this.result?.itemMeta?.persistentDataContainer?.decodePrefabs()
+                ?.contains(PrefabKey.of("mineinabyss:depth_meter")) == true
+        )
             result = null
     }
 }

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DoShowDepth.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DoShowDepth.kt
@@ -17,7 +17,7 @@ import kotlin.math.roundToInt
 
 class ShowDepthSystem : GearyListener() {
     private val Pointers.player by get<Player>().on(target)
-    private val Pointers.hasDepth by family { has<ShowDepth>() }.on(source)
+    private val Pointers.action by family { has<ShowDepth>() }.on(source)
 
     override fun Pointers.handle() {
         if (player.toGeary().has<ShowDepthMeterHud>()) return

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DoToggleDepthHud.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DoToggleDepthHud.kt
@@ -3,6 +3,7 @@ package com.mineinabyss.features.tools.depthmeter
 import com.mineinabyss.components.tools.ShowDepthMeterHud
 import com.mineinabyss.geary.annotations.optin.UnsafeAccessors
 import com.mineinabyss.geary.datatypes.family.family
+import com.mineinabyss.geary.papermc.datastore.encodeComponentsTo
 import com.mineinabyss.geary.systems.GearyListener
 import com.mineinabyss.geary.systems.accessors.Pointers
 import org.bukkit.enchantments.Enchantment
@@ -15,14 +16,16 @@ class DoToggleDepthHud : GearyListener() {
 
     @OptIn(UnsafeAccessors::class)
     override fun Pointers.handle() {
+        val item = item
         if (target.entity.has<ShowDepthMeterHud>()) {
-            target.entity.remove<ShowDepthMeterHud>()
             item.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1)
             item.addItemFlags(ItemFlag.HIDE_ENCHANTS)
+            target.entity.remove<ShowDepthMeterHud>()
         } else {
-            target.entity.setPersisting(ShowDepthMeterHud())
             item.removeEnchantment(Enchantment.ARROW_INFINITE)
             item.removeItemFlags(ItemFlag.HIDE_ENCHANTS)
+            target.entity.setPersisting(ShowDepthMeterHud())
         }
+        target.entity.encodeComponentsTo(item)
     }
 }

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DoToggleDepthHud.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/tools/depthmeter/DoToggleDepthHud.kt
@@ -1,28 +1,26 @@
 package com.mineinabyss.features.tools.depthmeter
 
-import com.mineinabyss.components.tools.DepthMeter
 import com.mineinabyss.components.tools.ShowDepthMeterHud
+import com.mineinabyss.geary.annotations.optin.UnsafeAccessors
 import com.mineinabyss.geary.datatypes.family.family
-import com.mineinabyss.geary.papermc.tracking.entities.toGeary
 import com.mineinabyss.geary.systems.GearyListener
 import com.mineinabyss.geary.systems.accessors.Pointers
 import org.bukkit.enchantments.Enchantment
-import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemFlag
+import org.bukkit.inventory.ItemStack
 
-class ToggleDepthHudSystem : GearyListener() {
-    private val Pointers.player by get<Player>().on(target)
-    private val Pointers.hasDepth by family { has<ToggleDepthHud>() }.on(source)
+class DoToggleDepthHud : GearyListener() {
+    private val Pointers.item by get<ItemStack>().on(target)
+    private val Pointers.action by family { has<ToggleDepthHud>() }.on(source)
 
+    @OptIn(UnsafeAccessors::class)
     override fun Pointers.handle() {
-        val item = player.inventory.itemInMainHand
-        if (player.toGeary().has<ShowDepthMeterHud>()) {
-            player.toGeary().remove<ShowDepthMeterHud>()
+        if (target.entity.has<ShowDepthMeterHud>()) {
+            target.entity.remove<ShowDepthMeterHud>()
             item.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1)
             item.addItemFlags(ItemFlag.HIDE_ENCHANTS)
-        }
-        else {
-            player.toGeary().setPersisting(ShowDepthMeterHud())
+        } else {
+            target.entity.setPersisting(ShowDepthMeterHud())
             item.removeEnchantment(Enchantment.ARROW_INFINITE)
             item.removeItemFlags(ItemFlag.HIDE_ENCHANTS)
         }


### PR DESCRIPTION
Rework the system to handle multiple items of the same type in inventory. If any is toggled to show hud, the player will get a component added to them. Also work in reverse, starting with relics, finding players holding them to update, to do less work.