### PR TITLE
feat: gondola system

### DIFF
--- a/mineinabyss-components/src/main/kotlin/com/mineinabyss/components/gondolas/Gondola.kt
+++ b/mineinabyss-components/src/main/kotlin/com/mineinabyss/components/gondolas/Gondola.kt
@@ -10,7 +10,14 @@ import org.bukkit.Location
 @SerialName("mineinabyss:gondola")
 class Gondola(
     @Serializable(with = LocationSerializer::class)
-    val location: Location,
-    val name: String,
-    val displayItem: SerializableItemStack,
-)
+    val upperLoc: Location,
+    @Serializable(with = LocationSerializer::class)
+    val lowerLoc: Location,
+    val name: String, // the name of the gondola
+    val unlockPrice: Int, // the price needed to unlock access to the line
+    val displayItem: SerializableItemStack, // the item to display in the GUI
+    val warpZoneRange: Double, // the range in which the player needs to stay in order to be teleported
+    val noAccessMessage: String, // the message to display when the player tries to use the gondola without perms
+) {
+    val warpCooldown = 5000
+}

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaFeature.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaFeature.kt
@@ -31,7 +31,8 @@ import com.mineinabyss.idofront.plugin.listeners
 class GondolaFeature : FeatureWithContext<GondolaFeature.Context>(::Context) {
 
     class Context : Configurable<GondolasConfig> {
-        override val configManager = config("gondolas", abyss.dataPath, GondolasConfig())
+        override val configManager =
+            config("gondolas", abyss.dataPath, GondolasConfig())
         val gondolasListener = GondolasListener()
     }
 
@@ -45,8 +46,6 @@ class GondolaFeature : FeatureWithContext<GondolaFeature.Context>(::Context) {
                 "list"(desc = "Opens the gondola menu") {
                     permission = "mineinabyss.gondola.list"
                     playerAction {
-                        val list_gondolas = context.config.gondolas
-                        //list_gondolas.forEach { println("Gondola: ${it.name} at ${it.location}") }
                         guiy { GondolaSelectionMenu(player) }
                     }
                 }
@@ -54,7 +53,8 @@ class GondolaFeature : FeatureWithContext<GondolaFeature.Context>(::Context) {
                     permission = "mineinabyss.gondola.unlock"
                     val gondola by stringArg()
                     playerAction {
-                        val gondolas = player.toGeary().get<UnlockedGondolas>() ?: return@playerAction
+                        val gondolas = player.toGeary().get<UnlockedGondolas>()
+                            ?: return@playerAction
                         gondolas.keys.add(gondola)
                         player.success("Unlocked $gondola")
                     }
@@ -62,8 +62,8 @@ class GondolaFeature : FeatureWithContext<GondolaFeature.Context>(::Context) {
                 "clear"(desc = "Removes all associated gondolas from a player") {
                     permission = "mineinabyss.gondola.clear"
                     playerAction {
-                        val list_gondolas = context.config.gondolas
-                        val gondolas = player.toGeary().getOrSetPersisting<UnlockedGondolas> { UnlockedGondolas() }
+                        val gondolas = player.toGeary()
+                            .getOrSetPersisting<UnlockedGondolas> { UnlockedGondolas() }
                         gondolas.keys.clear()
                         player.error("Cleared all gondolas")
                     }

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaGUI.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaGUI.kt
@@ -42,6 +42,6 @@ fun GondolaSpawn(player: Player, gondola: Gondola) = Item(
     gondola.displayItem.toItemStack()
         .editItemMeta { itemName(gondola.name.miniMsg()) },
     Modifier.clickable {
-        player.teleport(gondola.upperLoc)
+        player.teleportAsync(gondola.upperLoc)
     }
 )

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaGUI.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaGUI.kt
@@ -33,6 +33,6 @@ fun GondolaSelectionMenu(player: Player) {
 fun GondolaSpawn(player: Player, gondola: Gondola) = Item(
     gondola.displayItem.toItemStack().editItemMeta { itemName(gondola.name.miniMsg()) },
     Modifier.clickable {
-        player.teleport(gondola.location)
+        player.teleport(gondola.upperLoc)
     }
 )

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaGUI.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaGUI.kt
@@ -22,16 +22,25 @@ fun GondolaSelectionMenu(player: Player) {
     val gearyPlayer = player.toGeary()
     val gondolas = gearyPlayer.get<UnlockedGondolas>() ?: return
 
-    Chest(setOf(player), title = "Choose Spawn Location", onClose = { owner.exit() }) {
+    Chest(
+        setOf(player),
+        title = "Choose Spawn Location",
+        onClose = { owner.exit() }) {
         HorizontalGrid(Modifier.size(9, 6)) {
-            gondolas.keys.forEach { GondolaSpawn(player, LoadedGondolas.loaded[it] ?: return@forEach) }
+            gondolas.keys.forEach {
+                GondolaSpawn(
+                    player,
+                    LoadedGondolas.loaded[it] ?: return@forEach
+                )
+            }
         }
     }
 }
 
 @Composable
 fun GondolaSpawn(player: Player, gondola: Gondola) = Item(
-    gondola.displayItem.toItemStack().editItemMeta { itemName(gondola.name.miniMsg()) },
+    gondola.displayItem.toItemStack()
+        .editItemMeta { itemName(gondola.name.miniMsg()) },
     Modifier.clickable {
         player.teleport(gondola.upperLoc)
     }

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaTracker.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolaTracker.kt
@@ -8,6 +8,7 @@ import com.mineinabyss.geary.serialization.getOrSetPersisting
 import com.mineinabyss.geary.systems.query.query
 import org.bukkit.entity.Player
 
-fun Geary.createGondolaTracker() = observe<OnSet>().exec(query<Player>()) { player ->
+fun Geary.createGondolaTracker() =
+    observe<OnSet>().exec(query<Player>()) { player ->
         entity.getOrSetPersisting<UnlockedGondolas> { UnlockedGondolas() }
     }

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasConfig.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasConfig.kt
@@ -1,0 +1,14 @@
+package com.mineinabyss.features.gondolas
+
+import com.mineinabyss.components.gondolas.Gondola
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GondolasConfig (
+    val gondolas : Set<Gondola> = setOf()
+) {
+  init {
+    // set the gondolas to be loaded at startup
+    LoadedGondolas.loaded = gondolas.associateBy { it.name.lowercase() } as MutableMap<String, Gondola>
+  }
+}

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasConfig.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasConfig.kt
@@ -4,11 +4,12 @@ import com.mineinabyss.components.gondolas.Gondola
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class GondolasConfig (
-    val gondolas : Set<Gondola> = setOf()
+data class GondolasConfig(
+    val gondolas: Set<Gondola> = setOf()
 ) {
-  init {
-    // set the gondolas to be loaded at startup
-    LoadedGondolas.loaded = gondolas.associateBy { it.name.lowercase() } as MutableMap<String, Gondola>
-  }
+    init {
+        // set the gondolas to be loaded at startup
+        LoadedGondolas.loaded =
+            gondolas.associateBy { it.name.lowercase() } as MutableMap<String, Gondola>
+    }
 }

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasHelpers.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasHelpers.kt
@@ -12,7 +12,8 @@ enum class GondolaType() {
 }
 
 fun gondolaWarp(gondola: Gondola, player: Player, gondolaType: GondolaType) {
-    val loc = if (gondolaType == GondolaType.LOWER) gondola.upperLoc else gondola.lowerLoc
+    val loc =
+        if (gondolaType == GondolaType.LOWER) gondola.upperLoc else gondola.lowerLoc
     player.teleport(loc)
     player.sendMessage("You have been warped to ${gondola.name} at ${loc.x}, ${loc.y}, ${loc.z}")
 }

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasHelpers.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasHelpers.kt
@@ -1,0 +1,46 @@
+package com.mineinabyss.features.gondolas
+
+import com.mineinabyss.components.gondolas.Gondola
+import org.bukkit.entity.Player
+import org.bukkit.Location
+import kotlin.math.abs
+
+enum class GondolaType() {
+    UPPER,
+    LOWER,
+    NONE;
+}
+
+fun gondolaWarp(gondola: Gondola, player: Player, gondolaType: GondolaType) {
+    val loc = if (gondolaType == GondolaType.LOWER) gondola.upperLoc else gondola.lowerLoc
+    player.teleport(loc)
+    player.sendMessage("You have been warped to ${gondola.name} at ${loc.x}, ${loc.y}, ${loc.z}")
+}
+
+// AABB detection
+// returns if locations contains point within radius
+fun locContains(loc: Location, point: Location, radius: Double): Boolean {
+    return abs(loc.x - point.x) <= radius &&
+            abs(loc.y - point.y) <= radius &&
+            abs(loc.z - point.z) <= radius
+}
+
+fun getClosestGondolaType(gondola: Gondola, location: Location): GondolaType {
+    val radius = gondola.warpZoneRange
+    val upperLoc = gondola.upperLoc
+    val lowerLoc = gondola.lowerLoc
+
+    // 0 for upperLoc, 1 for lowerLoc
+    if (locContains(upperLoc, location, radius)) return GondolaType.UPPER
+    if (locContains(lowerLoc, location, radius)) return GondolaType.LOWER
+    return GondolaType.NONE
+}
+
+fun getGondolaFromName(gondolaName: String): Gondola? {
+    return LoadedGondolas.loaded.values.firstOrNull {
+        it.name.equals(
+            gondolaName,
+            ignoreCase = true
+        )
+    }
+}

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasHelpers.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasHelpers.kt
@@ -14,7 +14,7 @@ enum class GondolaType() {
 fun gondolaWarp(gondola: Gondola, player: Player, gondolaType: GondolaType) {
     val loc =
         if (gondolaType == GondolaType.LOWER) gondola.upperLoc else gondola.lowerLoc
-    player.teleport(loc)
+    player.teleportAsync(loc)
     player.sendMessage("You have been warped to ${gondola.name} at ${loc.x}, ${loc.y}, ${loc.z}")
 }
 

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasListener.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasListener.kt
@@ -1,0 +1,64 @@
+package com.mineinabyss.features.gondolas
+
+import com.mineinabyss.components.gondolas.UnlockedGondolas
+import com.mineinabyss.geary.papermc.tracking.entities.toGeary
+import com.mineinabyss.idofront.messaging.error
+import org.bukkit.event.Listener
+import org.bukkit.event.EventHandler
+import org.bukkit.event.player.PlayerMoveEvent
+import java.util.UUID
+
+class GondolasListener : Listener {
+    private val playerZoneEntry = mutableMapOf<UUID, Pair<String, Long>>()
+    private val justWarped = mutableSetOf<UUID>()
+    private val lastErrorTime = mutableMapOf<UUID, Long>()
+    private val errorCooldown = 5000
+
+    @EventHandler
+    fun onPlayerMove(event: PlayerMoveEvent) {
+        if (!event.hasExplicitlyChangedBlock()) return
+
+        val player = event.player
+        val gondolas = LoadedGondolas.loaded
+        val now = System.currentTimeMillis()
+        var inZone = false
+
+        for (gondola in gondolas.values) {
+            val unlockedGondolas =
+                player.toGeary().get<UnlockedGondolas>() ?: continue
+            val type = getClosestGondolaType(gondola, player.location)
+            if (type != GondolaType.NONE) {
+                inZone = true
+                if (gondola.name !in unlockedGondolas.keys) {
+                    val lastTime = lastErrorTime[player.uniqueId] ?: 0L
+                    if (now - lastTime >= errorCooldown) {
+                        player.error(gondola.noAccessMessage)
+                        lastErrorTime[player.uniqueId] = now
+                    }
+                    return
+                }
+                if (justWarped.contains(player.uniqueId)) return
+
+                val entry = playerZoneEntry[player.uniqueId]
+                if (entry?.first == gondola.name) {
+                    if (now - entry.second >= gondola.warpCooldown) {
+                        gondolaWarp(gondola, player, type)
+                        playerZoneEntry.remove(player.uniqueId)
+                        justWarped.add(player.uniqueId)
+                        return
+                    } else {
+                        val message =
+                            "Warping in ${((gondola.warpCooldown - (now - entry.second)) / 1000)} seconds..."
+                        player.sendActionBar(message)
+                        return
+                    }
+                } else {
+                    playerZoneEntry[player.uniqueId] = gondola.name to now
+                }
+                return
+            }
+        }
+        playerZoneEntry.remove(player.uniqueId)
+        justWarped.remove(player.uniqueId)
+    }
+}

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasListener.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/GondolasListener.kt
@@ -21,14 +21,18 @@ class GondolasListener : Listener {
         val player = event.player
         val gondolas = LoadedGondolas.loaded
         val now = System.currentTimeMillis()
-        var inZone = false
 
+        // iterate through all gondolas
         for (gondola in gondolas.values) {
             val unlockedGondolas =
                 player.toGeary().get<UnlockedGondolas>() ?: continue
+            // finds if  we are near a gondola upper/lower section
+            // type = GondolaType.NONE if not near a gondola
+            // type = GondolaType.UPPER if near upper section
+            // type = GondolaType.LOWER if near lower section
             val type = getClosestGondolaType(gondola, player.location)
             if (type != GondolaType.NONE) {
-                inZone = true
+                // ensure the player has access to the gondola
                 if (gondola.name !in unlockedGondolas.keys) {
                     val lastTime = lastErrorTime[player.uniqueId] ?: 0L
                     if (now - lastTime >= errorCooldown) {
@@ -37,8 +41,10 @@ class GondolasListener : Listener {
                     }
                     return
                 }
+                // warp cooldown
                 if (justWarped.contains(player.uniqueId)) return
 
+                // apply and check warp cooldown
                 val entry = playerZoneEntry[player.uniqueId]
                 if (entry?.first == gondola.name) {
                     if (now - entry.second >= gondola.warpCooldown) {

--- a/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/LoadedGondolas.kt
+++ b/mineinabyss-features/src/main/kotlin/com/mineinabyss/features/gondolas/LoadedGondolas.kt
@@ -8,10 +8,19 @@ import com.mineinabyss.geary.papermc.gearyPaper
 import com.mineinabyss.geary.systems.query.query
 import kotlin.collections.set
 
+/*
+ * Object containing the list of all active gondolas
+ * However, it seems that a player can have a gondola "unlocked" without it being loaded (and thus part of this map)
+ * Therefore, this map should represent the list of all "active" gondolas, that is, that can be used
+ * This implies that a player can unlock a gondola that can become inactive in one way or another
+ * The main benefit is that it allows to toggle gondolas on and off
+ * However this also means that we need to keep track of both the loaded gondolas and all the existing gondolas
+ * Therefore, this object contains the list of all **active** gondolas, which is different from the list of all **existing** gondolas
+ */
 object LoadedGondolas {
     //private val tracker = gearyPaper.gearyModule.setup.geary.observe<OnSet>().exec(query<Gondola>()) { (gondola) ->
     //    loaded[gondola.name] = gondola
     //}
 
-    val loaded = mutableMapOf<String, Gondola>()
+    var loaded = mutableMapOf<String, Gondola>()
 }


### PR DESCRIPTION
Simple gondola system.

Easy gondola creation via a config file.

Can modify :
- the upper and lower location of each gondolas
- Its name
- Unlock price
- Display item (in /mia gondola list)
- Warp zone range (the radius players needs to be inside to get teleported)
- The error message the gondola should display if an unauthorized player tries to use it
- The time it takes before the gondola teleports the player 

To unlock a gondola for a player: 
`player.toGeary().get<unlockedgondolas>()?.keys.add("Gondola name")`

Example config file:

```
gondolas:
  - upperLoc:
      x: 100.0
      y: 100.0
      z: 100.0
    lowerLoc:
      x: 0.0
      y: 100.0
      z: 0.0
    name: gondola1
    unlockPrice: 100
    displayItem:
      type: minecraft:stone
    warpZoneRange: 5.0
    noAccessMessage: you dont have access to gondola 1, you can go somewhere to buy
      access!
    warpCooldown: 5000
  - upperLoc:
      x: 100.0
      y: 100.0
      z: -100.0
    lowerLoc:
      x: -100.0
      y: 100.0
      z: 100.0
    name: gondola2
    unlockPrice: 100
    displayItem:
      type: minecraft:stone
    warpZoneRange: 5.0
    noAccessMessage: you dont have access to gondola 2...
    warpCooldown: 5000
```